### PR TITLE
Add support for embedded Picasa XMP face tags

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -38,7 +38,17 @@ function getFromImage(filename) {
                 let faces = [];
                 if (Object.prototype.hasOwnProperty.call(tags, "PersonInImage"))
                     faces = tags.PersonInImage;
-
+                // support for Picasa embedded face regions
+                else if (Object.prototype.hasOwnProperty.call(tags, "RegionInfo")) {
+                    out = [];
+                    for (i=0; i < tags.RegionInfo.RegionList.length; i++) {
+                        if (tags.RegionInfo.RegionList[i].Name)
+                            out[i] = tags.RegionInfo.RegionList[i].Name;
+                    }
+                    //console.log("Found Region Names: ", out);
+                    faces = out;
+                }
+            
                 resolve({
                     modif: modif,
                     faces: faces,


### PR DESCRIPTION
They're written in XMP:RegionName.