### PR TITLE
Update deleteTTPTags query

### DIFF
--- a/plex.js
+++ b/plex.js
@@ -82,7 +82,7 @@ function getPhotoLibraryId() {
 function getTTPTags(mid) {
 
     let sql = `SELECT A.id as tid,B.tag as tag   FROM taggings as A, tags as B 
-            WHERE A.metadata_item_id = ?
+            WHERE B.id = ?
             AND A.tag_id = B.id
             AND B.tag_type = 0
             AND B.extra_data='TTP'`;


### PR DESCRIPTION
It didn't seem to be doing what we wanted to? We're feeding it a tags.id as an argument, but then in the query we're comparing it to the metadata_item_id which, at least for me, never produced any hits? Can you verify this code?

Thanks.